### PR TITLE
Add asdf stanzas to build cl-repl using asdf:make

### DIFF
--- a/cl-repl.asd
+++ b/cl-repl.asd
@@ -1,8 +1,11 @@
-(defsystem cl-repl
+(asdf:defsystem cl-repl
   :version "0.7.0"
   :author "TANI Kojiro"
   :maintainer "Lisp Maintainers (https://github.com/lisp-maintainers/cl-repl)"
   :license "GPLv3"
+  :build-operation "program-op"
+  :build-pathname "cl-repl"
+  :entry-point "cl-repl:main"
   :depends-on (#:uiop
                #:unix-opts
                #:cl-ppcre


### PR DESCRIPTION
With these three arguments to `defsystem`, cl-repl can be build using `asdf:make` like

```lisp
(asdf:make "cl-repl")
```

This generates the executable `cl-repl` in the current working directory, using `cl-repl:main` as the program's main entry point.